### PR TITLE
show CiviCRM shortcut link on users.php on multisite

### DIFF
--- a/includes/civicrm-admin-utilities-single.php
+++ b/includes/civicrm-admin-utilities-single.php
@@ -382,8 +382,8 @@ class CiviCRM_Admin_Utilities_Single {
 		// Bail if user cannot access CiviCRM.
 		if ( ! current_user_can( 'access_civicrm' ) ) return $actions;
 
-		// Perform further checks if we can't view all contacts.
-		if ( ! $this->check_permission( 'view all contacts' ) ) {
+		// Perform further checks if we can't view all contacts and view all contact in domain on a multisite.
+		if ( ( ! $this->check_permission( 'view all contacts' ) ) && ( ! $this->check_permission( 'view all contacts in domain' ) ) ) {
 
 			//  Get current user.
 			$current_user = wp_get_current_user();


### PR DESCRIPTION
On multisite a site admin (not administrator) may have edit_users capability but not view all contacts. It should check for 'view all contacts in domain' for multisites. Still doesn't show on user-edit.php if not administrator though...