### PR TITLE
Accessibility: Update blue used in CSS to meet WCAG AA standards.

### DIFF
--- a/assets/css/civicrm-admin-utilities-admin-5-3-plus.css
+++ b/assets/css/civicrm-admin-utilities-admin-5-3-plus.css
@@ -62,8 +62,8 @@ Primary buttons
 	white-space: nowrap;
 	box-sizing: border-box;
 	box-shadow: none;
-	background: #007cba;
-	border-color: #007cba;
+	background: #2271b1;
+	border-color: #2271b1;
 	color: #fff;
 	text-decoration: none;
 	text-shadow: none;
@@ -105,7 +105,7 @@ Primary buttons
 /* Dialog buttons */
 .ui-dialog .ui-dialog-buttonpane button:focus
 {
-	box-shadow: 0 0 0 1px #fff, 0 0 0 3px #007cba;
+	box-shadow: 0 0 0 1px #fff, 0 0 0 3px #2271b1;
 }
 
 
@@ -207,9 +207,9 @@ body.wp-admin button.crm-button[crm-icon="fa-trash"]:focus,
 body.wp-admin .ui-dialog .ui-dialog-buttonpane button[data-op="no"]:focus
 {
 	background: #f3f5f6;
-	border-color: #007cba;
+	border-color: #2271b1;
 	color: #016087;
-	box-shadow: 0 0 0 1px #007cba;
+	box-shadow: 0 0 0 1px #2271b1;
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent;
 	/* Reset inherited offset from Gutenberg */
@@ -264,8 +264,8 @@ body #crm-container .crm-inline-edit.add-new .crm-edit-help
 	white-space: nowrap;
 	box-sizing: border-box;
 	box-shadow: none;
-	background: #007cba;
-	border-color: #007cba;
+	background: #2271b1;
+	border-color: #2271b1;
 	color: #fff;
 	text-decoration: none;
 	text-shadow: none;
@@ -284,7 +284,7 @@ body #crm-container .crm-edit-ready .crm-inline-edit:hover .crm-edit-help:focus
 body #crm-container .crm-edit-ready .crm-summary-block .crm-inline-edit:hover .crm-edit-help:focus,
 body #crm-container .crm-edit-ready .crm-inline-edit:hover .crm-edit-help:focus
 {
-	box-shadow: 0 0 0 1px #fff, 0 0 0 3px #007cba;
+	box-shadow: 0 0 0 1px #fff, 0 0 0 3px #2271b1;
 }
 
 

--- a/assets/css/civicrm-admin-utilities-admin.css
+++ b/assets/css/civicrm-admin-utilities-admin.css
@@ -1703,8 +1703,8 @@ div.crm-container .crm-content label.error
 }
 
 #crm-container ul.wizard-bar li.current-step {
-	background-color: #4A89DC;
-	border-color: #4A89DC;
+	background-color: #2271b1;
+	border-color: #2271b1;
 	color: #ffffff;
 	font-weight: bold;
 }
@@ -2263,7 +2263,7 @@ div.crm-container .crm-content label.error
 	border-radius: 3px;
 	white-space: nowrap;
 	box-sizing: border-box;
-	border-color: #007cba;
+	border-color: #2271b1;
 	text-decoration: none;
 	color: #0071a1;
 	border-color: #0071a1;
@@ -5192,8 +5192,8 @@ body #crm-container .crm-inline-edit.add-new .crm-edit-help
 	border-radius: 3px;
 	white-space: nowrap;
 	box-sizing: border-box;
-	background: #0085ba;
-	background-color: #0085ba;
+	background: #2271b1;
+	background-color: #2271b1;
 	border-color: #0073aa #006799 #006799;
 	box-shadow: 0 1px 0 #006799;
 	color: #fff;
@@ -5206,8 +5206,8 @@ body #crm-container .crm-inline-edit.add-new .crm-edit-help
 body #crm-container .crm-edit-ready .crm-summary-block .crm-inline-edit:hover .crm-edit-help,
 body #crm-container .crm-edit-ready .crm-inline-edit:hover .crm-edit-help
 {
-	background: #0085ba;
-	background-color: #0085ba;
+	background: #2271b1;
+	background-color: #2271b1;
 }
 
 body #crm-container .crm-edit-ready .crm-summary-block .crm-inline-edit:hover .crm-edit-help:hover,
@@ -5245,7 +5245,7 @@ body #crm-container .crm-edit-ready .crm-inline-edit:hover .crm-edit-help:focus
 /* Style the "Tags" title */
 #contact-summary .crm-summary-block #tagLink a
 {
-	color: #007bba;
+	color: #2271b1;
 	line-height: 1;
 	text-decoration: none;
 	position: relative;


### PR DESCRIPTION
The old shade of blue did not have sufficient contrast in the areas where it was used.

The new shade (#2271b1) has been chosen to match the colour used in WordPress core.
See also https://lab.civicrm.org/dev/accessibility/-/issues/11