### PR TITLE
Fix accordions in Civi 5.69+

### DIFF
--- a/assets/css/civicrm-admin-utilities-admin.css
+++ b/assets/css/civicrm-admin-utilities-admin.css
@@ -3136,7 +3136,8 @@ div.crm-master-accordion-header a.helpicon {
 	background-image: url("../images/civicrm-legacy/TreePlusWhite.gif");
 }
 
-.crm-container .collapsed .crm-accordion-body,
+.crm-container div.collapsed .crm-accordion-body,
+.crm-container fieldset.collapsed .crm-accordion-body,
 .crm-container .crm-collapsible.collapsed .collapsible-title + * {
 	display: none;
 }


### PR DESCRIPTION
CiviCRM 5.69 introduces a11y improvements for accordions, but this breaks Radstock.

You can replicate this on the Advanced Search page by attempting to expand any accordions.

This ports https://github.com/civicrm/civicrm-core/pull/28541 and https://github.com/civicrm/civicrm-core/pull/28781 to Radstock, which fixes the issue.